### PR TITLE
Display fragment template source

### DIFF
--- a/pinax_theme_tester/configs/base.py
+++ b/pinax_theme_tester/configs/base.py
@@ -6,7 +6,7 @@ from pinax_theme_tester.views import as_view
 
 class ViewConfig(object):
 
-    def __init__(self, name, pattern, template, pattern_kwargs, menu=True, display_name=None, **kwargs):
+    def __init__(self, name, pattern, template, pattern_kwargs, menu=True, display_name=None, template_source=None, **kwargs):
         self.name = name
         self.pattern = pattern
         self.template = template
@@ -14,6 +14,7 @@ class ViewConfig(object):
         self.pattern_kwargs = pattern_kwargs
         self.menu = menu
         self._display_name = display_name
+        self.template_source = template_source  # explicit path to template source, or a list of template source paths
         self.context.update(dict(current_view=self))
 
     def make_view(self):

--- a/pinax_theme_tester/configs/calendars.py
+++ b/pinax_theme_tester/configs/calendars.py
@@ -41,7 +41,13 @@ label = "calendars"
 title = "Pinax Calendars"
 
 views = [
-    ViewConfig(pattern=r"^templatetags/$", template="templatetags_calendars.html", name="calendars_templatetags", pattern_kwargs={}, **context),
+    ViewConfig(
+        pattern=r"^templatetags/$",
+        template="templatetags_calendars.html",
+        template_source="pinax/calendars/calendar.html",
+        name="calendars_templatetags",
+        pattern_kwargs={},
+        **context),
     # Fake urls to handle adapter reverse() calls
     ViewConfig(pattern="(?P<year>\d+)/(?P<month>\d+)/", template="", name="monthly", pattern_kwargs={}, menu=False),
     ViewConfig(pattern="(?P<year>\d+)/(?P<month>\d+)/(?P<day>\d+)/", template="", name="daily", pattern_kwargs={}, menu=False),

--- a/pinax_theme_tester/configs/general.py
+++ b/pinax_theme_tester/configs/general.py
@@ -29,7 +29,20 @@ title = "General"
 views = [
     ViewConfig(pattern=r"^general/404/$", template="404.html", name="general_400", pattern_kwargs={}),
     ViewConfig(pattern=r"^general/500/$", template="500.html", name="general_500", pattern_kwargs={}),
-    ViewConfig(pattern=r"^general/fragments/$", template="fragments.html", name="general_fragments", pattern_kwargs={}, messages=messages, is_paginated=True, page_obj=page_obj, paginator=paginator),
+    ViewConfig(
+        pattern=r"^general/fragments/$",
+        template="fragments.html",
+        template_source=[
+            "_account_bar.html",
+            "pagination/_pagination.html",
+            "_messages.html",
+        ],
+        name="general_fragments",
+        pattern_kwargs={},
+        messages=messages,
+        is_paginated=True,
+        page_obj=page_obj,
+        paginator=paginator),
 ]
 urlpatterns = [
     view.url()

--- a/pinax_theme_tester/configs/invitations.py
+++ b/pinax_theme_tester/configs/invitations.py
@@ -47,7 +47,18 @@ class NamespacedViewConfig(ViewConfig):
         return reverse("{}:{}".format(url_namespace, self.name), kwargs=self.pattern_kwargs)
 
 views = [
-    NamespacedViewConfig(pattern=r"^fragments/$", template="fragments_invitations.html", name="invitations_fragments", pattern_kwargs={}, **context),
+    NamespacedViewConfig(
+        pattern=r"^fragments/$",
+        template="fragments_invitations.html",
+        template_source=[
+            "pinax/invitations/_invite_form.html",
+            "pinax/invitations/_invited.html",
+            "pinax/invitations/_invites_remaining.html",
+        ],
+        name="invitations_fragments",
+        pattern_kwargs={},
+        **context),
+
     # Fake urls to handle template {% url %} needs
     NamespacedViewConfig(pattern=r"", template="", name="invite", pattern_kwargs={}, menu=False)
 ]

--- a/pinax_theme_tester/configs/likes.py
+++ b/pinax_theme_tester/configs/likes.py
@@ -27,7 +27,17 @@ label = "likes"
 title = "Pinax Likes"
 
 views = [
-    ViewConfig(pattern=r"^fragments/$", template="fragments_likes.html", name="likes_fragments", pattern_kwargs={}, **context),
+    ViewConfig(
+        pattern=r"^fragments/$",
+        template="fragments_likes.html",
+        template_source=[
+            "pinax/likes/_like.html",
+            "pinax/likes/_widget_brief.html",
+            "pinax/likes/_widget.html",
+        ],
+        name="likes_fragments",
+        pattern_kwargs={},
+        **context),
 ]
 urlpatterns = [
     view.url()

--- a/pinax_theme_tester/configs/waitinglist.py
+++ b/pinax_theme_tester/configs/waitinglist.py
@@ -21,7 +21,16 @@ class NamespacedViewConfig(ViewConfig):
         return reverse("{}:{}".format(url_namespace, self.name), kwargs=self.pattern_kwargs)
 
 views = [
-    NamespacedViewConfig(pattern=r"^fragments/$", template="fragments_waitinglist.html", name="waitinglist_fragments", pattern_kwargs={}, **context),
+    NamespacedViewConfig(
+        pattern=r"^fragments/$",
+        template="fragments_waitinglist.html",
+        template_source=[
+            "pinax/waitinglist/_list_signup.html",
+            "pinax/waitinglist/_success.html",
+        ],
+        name="waitinglist_fragments",
+        pattern_kwargs={},
+        **context),
     # Fake urls to handle template {% url %} needs
     NamespacedViewConfig(pattern=r"", template="", name="ajax_list_signup", pattern_kwargs={}, menu=False),
 ]

--- a/pinax_theme_tester/templates/source.html
+++ b/pinax_theme_tester/templates/source.html
@@ -3,8 +3,16 @@
 {% block messages %}{% endblock %}
 
 {% block body %}
+    {% if usage_source %}
 <div class="source-container">
-    <h2>{{ template_name }}</h2>
-    {{ template_source|safe }}
+    <h2>Usage</h2>
+    {{ usage_source|safe }}
 </div>
+    {% endif %}
+    {% for template in templates %}
+<div class="source-container">
+    <h2>{{ template.name }}</h2>
+    {{ template.source|safe }}
+</div>
+    {% endfor %}
 {% endblock %}

--- a/pinax_theme_tester/views.py
+++ b/pinax_theme_tester/views.py
@@ -9,6 +9,7 @@ from pygments.formatters import HtmlFormatter
 class TemplateWithContextView(TemplateView):
     context = None
     config = None
+    usage_name = None
 
     def get_template_names(self):
         if self.request.GET.get("source"):
@@ -17,10 +18,36 @@ class TemplateWithContextView(TemplateView):
 
     def get_context_data(self, *args, **kwargs):
         ctx = super(TemplateWithContextView, self).get_context_data(*args, **kwargs)
-        if self.template_name:
-            template = get_template(self.template_name)
-            source = highlight(template.template.source, DjangoLexer(), HtmlFormatter())
-            ctx.update({"template_source": source, "template_name": self.template_name})
+
+        if self.config and self.config.template_source:
+            # Explicit template source(s) takes priority
+            if isinstance(self.config.template_source, str):
+                # single template source file path
+                template_sources = [self.config.template_source]
+                if self.template_name and self.template_name != self.config.template_source:
+                    self.usage_name = self.template_name
+            else:
+                # expecting an iterable of template source file paths
+                template_sources = self.config.template_source
+                self.usage_name = self.template_name
+        elif self.template_name:
+            # Default template
+            template_sources = [self.template_name]
+
+        templates = []
+        for source in template_sources:
+            # Add dictionary with name and source
+            template = get_template(source)
+            template_source = highlight(template.template.source, DjangoLexer(), HtmlFormatter())
+            templates.append(dict(name=source, source=template_source))
+        ctx.update({"templates": templates})
+
+        # Display snippet usage
+        if self.usage_name:
+            usage = get_template(self.usage_name)
+            usage_source = highlight(usage.template.source, DjangoLexer(), HtmlFormatter())
+            ctx.update({"usage_source": usage_source})
+
         if self.context is not None:
             ctx.update(self.context)
         return ctx


### PR DESCRIPTION
Reference issue #22.

Add `template_source` option to ViewConfig.
`template_source` kwarg allows specification of one or more source files to display alongside the actual template rendered. `template_source` can be a single template path string or a list of paths. If `template_source` is specified, the actual rendered template source is displayed under a "Usage" heading.

Setting `template_source` is useful when the rendered template uses {% include %} or templatetags, i.e. 

```django
{% load pinax_calendars_tags %}
{% calendar events today %}

{% include "pinax/messages/_invite_form.html" %}
```